### PR TITLE
Fix website CSS reference

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,6 @@
   <meta charset="UTF-8">
   <title>{{ page.title }} - {{ site.title }}</title>
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/style.css">
   <style>
     .navbar-custom {
       background-color: #0072b1;


### PR DESCRIPTION
## Summary
- remove link to a nonexistent CSS file in default layout

## Testing
- `bundle exec jekyll build` *(fails: bundler not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685da57dbe48832f859347696baae43c